### PR TITLE
Implement actionsBlacklist like in RN debugger

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,3 +57,21 @@ For more information about cyclic reference, visit [MDN Cyclic Object](https://d
 ```javascript
 let reduxDebugger = createDebugger({ resolveCyclic: true });
 ```
+
+### Actions Blacklist
+
+You may specify an actions blacklist the same way as with React Native Debugger, by providing an
+array of strings to match against the action.type field.
+This feature can be enabled by passing `{ actionsBlacklist }` into `createDebugger`,
+where `actionsBlacklist` is an array of strings.
+
+For example:
+
+```javascript
+const actionsBlackList = ['EVENTS/', 'LOCAL/setClock'];
+const reduxDebugger = createDebugger({ actionsBlackList });
+```
+
+This will exclude any actions that contain the substrings in the blacklist. So an action with type
+`EVENTS/foo` will not be sent to the redux debugger flipper plugin, but an action with type
+`LOCAL/anotherAction` will.

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,16 +3,17 @@ import * as dayjs from 'dayjs';
 
 type Configuration = {
   resolveCyclic: boolean;
+  actionsBlacklist: Array<String>;
 };
 
-const defaultConfig: Configuration = { resolveCyclic: false };
+const defaultConfig: Configuration = { resolveCyclic: false, actionsBlacklist: [] };
 
 let currentConnection: any = null;
 const error = {
   NO_STORE: 'NO_STORE',
 };
 
-const createDebugger = ({ resolveCyclic }: Configuration = defaultConfig) => (
+const createDebugger = ({ resolveCyclic, actionsBlacklist }: Configuration = defaultConfig) => (
   store: any,
 ) => {
   if (currentConnection == null) {
@@ -73,7 +74,19 @@ const createDebugger = ({ resolveCyclic }: Configuration = defaultConfig) => (
         before,
         after,
       };
-      currentConnection.send('actionDispatched', state);
+
+      let blackListed = false;
+      if (actionsBlacklist.length) {
+        for (const substr of actionsBlacklist) {
+          if (action.type.includes(substr)) {
+            blackListed = true;
+            break;
+          }
+        }
+      }
+      if (!blackListed) {
+        currentConnection.send('actionDispatched', state);
+      }
     }
 
     return result;


### PR DESCRIPTION
For some time, people are still likely to need to use RN debugger together with flipper.

This PR implements the `actionsBlacklist` middleware debugging option (named the same as RN debugger https://github.com/jhen0409/react-native-debugger/blob/2ea070367a39d065be737a060fddf479326db054/app/worker/reduxAPI.js#L231) to keep things consistent for developers.

As implemented, any substring in the blacklist that is matched by the `action.type` will not be sent to the flipper plugin.