### PR TITLE
Add ability to whitelist certain keys from state

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,9 @@ cd ios && pod install
 ```javascript
 import { createStore, applyMiddleware } from 'redux';
 
-const middlewares = [/* other middlewares */];
+const middlewares = [
+  /* other middlewares */
+];
 
 if (__DEV__) {
   const createDebugger = require('redux-flipper').default;
@@ -45,6 +47,26 @@ Manage Plugins > Install Plugins > search "redux-debugger" > Install
 4. Start your app, then you should be able to see Redux Debugger on your Flipper app
 
 ## Optional Configuration
+
+### State whitelisting
+
+Many times you are only interested in certain part of the Redux state when debugging. You can pass array of string which have to match to the root key of the Redux state.
+
+For example if Redux schema is something like this and you are only interested in user then you can whitelist only that part of the state
+
+```typescript
+type ReduxState = {
+  todos: string[];
+  notifications: string[];
+  user: {
+    name: string;
+  };
+};
+```
+
+```javascript
+let reduxDebugger = createDebugger({ stateWhitelist: ['user'] });
+```
 
 ### Resolve cyclic reference
 

--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ type ReduxState = {
 let reduxDebugger = createDebugger({ stateWhitelist: ['user'] });
 ```
 
+If you app has very big state tree it is also good idea to whitelist certain keys from Redux state otherwise Flipper can be very slow.
+
 ### Resolve cyclic reference
 
 Redux Debugger does not support cyclic reference objects by default as resolving it makes application slow. This feature can be enabled by passing `{ resolveCyclic: true }` into `createDebugger`.

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
   ],
   "license": "MIT",
   "scripts": {
-    "build": "tsc"
+    "build": "tsc",
+    "dev": "tsc -w"
   },
   "peerDependencies": {
     "react-native": "^0.62.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import { addPlugin, Flipper } from 'react-native-flipper';
 import * as dayjs from 'dayjs';
 
-type Configuration = {
+export type Configuration = {
   resolveCyclic: boolean;
   actionsBlacklist: Array<string>;
   stateWhitelist: string[];

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,9 +2,9 @@ import { addPlugin, Flipper } from 'react-native-flipper';
 import * as dayjs from 'dayjs';
 
 export type Configuration = {
-  resolveCyclic: boolean;
-  actionsBlacklist: Array<string>;
-  stateWhitelist: string[];
+  resolveCyclic?: boolean;
+  actionsBlacklist?: Array<string>;
+  stateWhitelist?: string[];
 };
 
 const defaultConfig: Configuration = {
@@ -20,7 +20,7 @@ const error = {
 };
 
 const createStateForAction = (state: any, config: Configuration) => {
-  return config.stateWhitelist.length
+  return config.stateWhitelist?.length
     ? config.stateWhitelist.reduce(
         (acc, stateWhitelistedKey) => ({
           ...acc,
@@ -88,13 +88,9 @@ const createDebugger = (config = defaultConfig) => (store: any) => {
         after: createStateForAction(after, config),
       };
 
-      let blackListed = false;
-      for (const substr of config.actionsBlacklist) {
-        if (action.type.includes(substr)) {
-          blackListed = true;
-          break;
-        }
-      }
+      const blackListed = !!config.actionsBlacklist?.some(
+        (blacklistedActionType) => action.type.includes(blacklistedActionType),
+      );
       if (!blackListed) {
         currentConnection.send('actionDispatched', state);
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,10 +16,7 @@ const error = {
   NO_STORE: 'NO_STORE',
 };
 
-const createDebugger = ({
-  resolveCyclic,
-  actionsBlacklist,
-}: Configuration = defaultConfig) => (store: any) => {
+const createDebugger = (config = defaultConfig) => (store: any) => {
   if (currentConnection == null) {
     addPlugin({
       getId() {
@@ -63,7 +60,7 @@ const createDebugger = ({
       let after = store.getState();
       let now = Date.now();
 
-      if (resolveCyclic) {
+      if (config.resolveCyclic) {
         const cycle = require('cycle');
 
         before = cycle.decycle(before);
@@ -80,12 +77,10 @@ const createDebugger = ({
       };
 
       let blackListed = false;
-      if (actionsBlacklist && actionsBlacklist.length) {
-        for (const substr of actionsBlacklist) {
-          if (action.type.includes(substr)) {
-            blackListed = true;
-            break;
-          }
+      for (const substr of config.actionsBlacklist) {
+        if (action.type.includes(substr)) {
+          blackListed = true;
+          break;
         }
       }
       if (!blackListed) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { addPlugin } from 'react-native-flipper';
+import { addPlugin, Flipper } from 'react-native-flipper';
 import * as dayjs from 'dayjs';
 
 type Configuration = {
@@ -11,7 +11,8 @@ const defaultConfig: Configuration = {
   actionsBlacklist: [],
 };
 
-let currentConnection: any = null;
+let currentConnection: Flipper.FlipperConnection | null = null;
+
 const error = {
   NO_STORE: 'NO_STORE',
 };
@@ -22,28 +23,25 @@ const createDebugger = (config = defaultConfig) => (store: any) => {
       getId() {
         return 'flipper-plugin-redux-debugger';
       },
-      onConnect(connection: any) {
+      onConnect(connection) {
         currentConnection = connection;
 
-        currentConnection.receive(
-          'dispatchAction',
-          (data: any, responder: any) => {
-            console.log('flipper redux dispatch action data', data);
-            // respond with some data
-            if (store) {
-              store.dispatch({ type: data.type, ...data.payload });
+        currentConnection.receive('dispatchAction', (data, responder) => {
+          console.log('flipper redux dispatch action data', data);
+          // respond with some data
+          if (store) {
+            store.dispatch({ type: data.type, ...data.payload });
 
-              responder.success({
-                ack: true,
-              });
-            } else {
-              responder.success({
-                error: error.NO_STORE,
-                message: 'store is not setup in flipper plugin',
-              });
-            }
-          },
-        );
+            responder.success({
+              ack: true,
+            });
+          } else {
+            responder.success({
+              error: error.NO_STORE,
+              message: 'store is not setup in flipper plugin',
+            });
+          }
+        });
       },
       onDisconnect() {},
       runInBackground() {

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,6 @@ export type Configuration = {
 const defaultConfig: Configuration = {
   resolveCyclic: false,
   actionsBlacklist: [],
-  stateWhitelist: [],
 };
 
 let currentConnection: Flipper.FlipperConnection | null = null;
@@ -20,7 +19,7 @@ const error = {
 };
 
 const createStateForAction = (state: any, config: Configuration) => {
-  return config.stateWhitelist?.length
+  return config.stateWhitelist
     ? config.stateWhitelist.reduce(
         (acc, stateWhitelistedKey) => ({
           ...acc,

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,17 +4,31 @@ import * as dayjs from 'dayjs';
 type Configuration = {
   resolveCyclic: boolean;
   actionsBlacklist: Array<string>;
+  stateWhitelist: string[];
 };
 
 const defaultConfig: Configuration = {
   resolveCyclic: false,
   actionsBlacklist: [],
+  stateWhitelist: [],
 };
 
 let currentConnection: Flipper.FlipperConnection | null = null;
 
 const error = {
   NO_STORE: 'NO_STORE',
+};
+
+const createStateForAction = (state: any, config: Configuration) => {
+  return config.stateWhitelist.length
+    ? config.stateWhitelist.reduce(
+        (acc, stateWhitelistedKey) => ({
+          ...acc,
+          [stateWhitelistedKey]: state[stateWhitelistedKey],
+        }),
+        {},
+      )
+    : state;
 };
 
 const createDebugger = (config = defaultConfig) => (store: any) => {
@@ -70,8 +84,8 @@ const createDebugger = (config = defaultConfig) => (store: any) => {
         time: dayjs(startTime).format('HH:mm:ss.SSS'),
         took: `${now - startTime} ms`,
         action,
-        before,
-        after,
+        before: createStateForAction(before, config),
+        after: createStateForAction(after, config),
       };
 
       let blackListed = false;

--- a/yarn.lock
+++ b/yarn.lock
@@ -942,10 +942,10 @@ punycode@^2.1.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
 
-react-native-flipper@^0.49.0:
-  version "0.49.0"
-  resolved "https://registry.yarnpkg.com/react-native-flipper/-/react-native-flipper-0.49.0.tgz#8fd19b7cd8af1e7772ece07e54366aa751a87016"
-  integrity sha512-Y0fIwEyEsouYKbyve71Ps7cUryDcEGLY2EOyve6p9gNMDdpVIfo040JgwCOD/2s+AjWK3C7F0wl4IXIrnF+wiA==
+react-native-flipper@^0.55.0:
+  version "0.55.0"
+  resolved "https://registry.yarnpkg.com/react-native-flipper/-/react-native-flipper-0.55.0.tgz#1fb0e280eff2224f2ab5b3f429896e05112ced41"
+  integrity sha512-z2FARpeCfMWVn4zdYJtpGiYqcmo48dCuAjEI3CdkCewjQVNrT5DxUm33Yr/iM1HnTzVKRKsluPuPsKJXXHaQtw==
 
 read-pkg-up@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
## Description

We noticed same slowness as issue #27 . The reason for slowness is that if your app has huge Redux state then Flipper is making app veeeeryyyy slow. Solution for this is it only watch certain keys of your Redux state.

This change is necessary in any way since often times in big production apps the store has 30 different root keys and you are only interested only in one when debugging. And you can still see the whole state if you want if you don't specify `stateWhitelist`


## How to test?

Add `stateWhitelist` to your configuration and add some keys to the array which are included in your Redux state and see from Flipper app that only that part of the state is logged on actions


Fixes #27 