### PR TITLE
add flexibility to peerDeps for newer versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,8 +27,8 @@
     "dev": "tsc -w"
   },
   "peerDependencies": {
-    "react-native": "^0.63.0",
-    "react-native-flipper": "^0.100.0",
+    "react-native": ">=0.63.0",
+    "react-native-flipper": ">=0.100.0",
     "redux": "^4"
   },
   "devDependencies": {


### PR DESCRIPTION
Resolving these warnings. 
```
npm WARN redux-flipper@2.0.0 requires a peer of react-native@^0.63.0 but none is installed. You must install peer dependencies yourself.
npm WARN redux-flipper@2.0.0 requires a peer of react-native-flipper@^0.100.0 but none is installed. You must install peer dependencies yourself.
```